### PR TITLE
Almost Amazon Template Uses Client Now

### DIFF
--- a/src/data/curriculum/client/week-09/01-user-data-refactor.md
+++ b/src/data/curriculum/client/week-09/01-user-data-refactor.md
@@ -67,11 +67,11 @@ import firebase from 'firebase/app'; // import the firebase app dependency
 import 'firebase/auth'; // import the firebase auth dependency
 import loginButton from '../components/buttons/loginButton';
 import startApp from './startApp';
-import firebaseConfig from '../../api/apiKeys';
+import client from './client';
 
 const ViewDirectorBasedOnUserAuthStatus = () => {
   // This line initializes your firebase app using the values from your .env file
-  firebase.initializeApp(firebaseConfig);
+  firebase.initializeApp(client);
 
   // This function is looking for anytime the Auth State Changes.
   // In this app, this happens on 2 occasions:


### PR DESCRIPTION
The code to update the `viewDirector.js` file had us referencing a file called `apiKeys` which is not in the newest template. Instead, we are using client. I confirmed this was in line with what Aja has in her Almost Amazon repo.